### PR TITLE
Adds crawling Citations/Year, Adds Option to use proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,19 @@ Here's a quick example demonstrating how to retrieve an author's profile then re
     >>> print([citation.bib['title'] for citation in pub.get_citedby()])
 ```
 
+### Using a proxy
+Just run `scholarly.use_proxy()`. Parameters are an http and an https proxy.
+*Note: this is a completely optional - opt-in feature'
+
+```python
+    >>> # default values are shown below
+    >>> proxies = {'http' : 'socks5://127.0.0.1:9050', 'https': 'socks5://127.0.0.1:9050'}
+    >>> scholarly.use_proxy(**proxies)
+    >>> # If proxy is correctly set up, the following runs through it
+    >>> scholarly.search_author('Steven A Cholewiak')
+    >>>
+
+```
 
 ## Installation
 Use `pip` to install from pypi:
@@ -109,6 +122,7 @@ or clone the package using git:
 
 ## Requirements
 Requires [arrow](http://crsmithdev.com/arrow/), [Beautiful Soup](https://pypi.python.org/pypi/beautifulsoup4/), [bibtexparser](https://pypi.python.org/pypi/bibtexparser/), and [requests[security]](https://pypi.python.org/pypi/requests/).
+Also [pysocks](https://pypi.org/project/PySocks/) for using a proxy.
 
 
 ## License

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 arrow
 beautifulsoup4
 bibtexparser
+pysocks
 requests[security]

--- a/scholarly/scholarly.py
+++ b/scholarly/scholarly.py
@@ -40,6 +40,16 @@ _SESSION = requests.Session()
 _PAGESIZE = 100
 
 
+def use_proxy(http='socks5://127.0.0.1:9050', https='socks5://127.0.0.1:9050'):
+    """ Routes scholarly through a proxy (e.g. tor).
+        Requires pysocks
+        Proxy must be running."""
+    _SESSION.proxies ={
+            'http': http,
+            'https': https
+    }
+
+
 def _handle_captcha(url):
     # TODO: PROBLEMS HERE! NEEDS ATTENTION
     # Get the captcha image


### PR DESCRIPTION
1. Adds Citations/Year in the result set, which is a useful metric that was being ignored.

2. Adds `scholarly.use_proxy()` function to divert traffic through a proxy. Useful to anonymize requests. Proxy needs to be already set up and `pysocks` is needed. Uses [this](http://docs.python-requests.org/en/master/user/advanced/#proxies) feature of requests library.