### PR TITLE
Add search by author id

### DIFF
--- a/scholarly/__init__.py
+++ b/scholarly/__init__.py
@@ -1,3 +1,4 @@
 from .scholarly import Author, Publication
 from .scholarly import search_author, search_keyword, search_pubs_query
 from .scholarly import search_pubs_custom_url, search_author_custom_url
+from .scholarly import search_author_id

--- a/scholarly/test.py
+++ b/scholarly/test.py
@@ -55,6 +55,12 @@ class TestScholarly(unittest.TestCase):
         self.assertEqual(author.name, u'Steven A. Cholewiak')
         self.assertEqual(author.id, u'4bahYMkAAAAJ')
 
+    def test_author_id(self):
+        author = scholarly.search_author_id('qc6CJjYAAAAJ')
+        self.assertEqual(author.name, u'Albert Einstein')
+
+    def test_bad_author_id(self):
+        self.assertRaises(Exception, scholarly.search_author_id, 'IHOPETHISISNEVERANID')
+
 if __name__ == '__main__':
     unittest.main()
-

--- a/scholarly/test.py
+++ b/scholarly/test.py
@@ -8,9 +8,9 @@ class TestScholarly(unittest.TestCase):
         self.assertIs(len(authors), 0)
 
     def test_empty_keyword(self):
-        ''' Returns 4 individuals with the name 'label' '''
+        ''' Returns 5 (s of 8/8/2019) individuals with the name 'label' '''
         authors = [a for a in scholarly.search_keyword('')]
-        self.assertEqual(len(authors), 4)
+        self.assertEqual(len(authors), 5)
 
     def test_empty_publication(self):
         pubs = [p for p in scholarly.search_pubs_query('')]
@@ -27,15 +27,15 @@ class TestScholarly(unittest.TestCase):
         self.assertIn(u'Steven A. Cholewiak', authors)
 
     def test_multiple_authors(self):
-        ''' As of March 14, 2019 there are 34 'Zucker's '''
+        ''' As of August 8, 2019 there are 62 'Zucker's '''
         authors = [a.name for a in scholarly.search_author('Zucker')]
-        self.assertEqual(len(authors), 58)
+        self.assertEqual(len(authors), 62)
         self.assertIn(u'Steven W Zucker', authors)
 
     def test_multiple_publications(self):
-        ''' As of March 14, 2019 there are 28 pubs that fit the search term'''
+        ''' As of August 8, 2019 there are 28 pubs that fit the search term'''
         pubs = [p.bib['title'] for p in scholarly.search_pubs_query('"naive physics" stability "3d shape"')]
-        self.assertEqual(len(pubs), 28)
+        self.assertEqual(len(pubs), 29)
         self.assertIn(u'Visual perception of the physical stability of asymmetric three-dimensional objects', pubs)
 
     def test_publication_contents(self):


### PR DESCRIPTION
Added a basic function to search for a particular author id. This will either generate a single Author object if the ID is known or will raise an `Exception` if the id is unknown.

Use case: I wanted to use `scholarly` to check my own citations etc. and then use this to update a site or CV template. Currently it was necessary to search for my name and check the id of each Author object returned to work out which was me. At best this resulted in at least one unneeded call of `_get_soup()` and did not seem like an elegant solution.

I've added two tests to cover a valid and an invalid author id and also updated three of the existing tests which were failing as either other additional authors or citations are now listed.

Apologies if I missed a standard PR template, I couldn't see one based on other PRs here.