### PR TITLE
Fix empty get_citedby() result

### DIFF
--- a/scholarly/scholarly.py
+++ b/scholarly/scholarly.py
@@ -14,6 +14,7 @@ import re
 import requests
 import sys
 import time
+import urllib
 
 _GOOGLEID = hashlib.md5(str(random.random()).encode('utf-8')).hexdigest()[:16]
 _COOKIES = {'GSP': 'ID={0}:CF=4'.format(_GOOGLEID)}
@@ -21,7 +22,7 @@ _HEADERS = {
     'accept-language': 'en-US,en',
     'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/41.0.2272.76 Chrome/41.0.2272.76 Safari/537.36',
     'accept': 'text/html,application/xhtml+xml,application/xml'
-    }
+}
 _HOST = 'https://scholar.google.com'
 _AUTHSEARCH = '/citations?view_op=search_authors&hl=en&mauthors={0}'
 _CITATIONAUTH = '/citations?user={0}&hl=en'
@@ -39,7 +40,6 @@ _EMAILAUTHORRE = r'Verified email at '
 _SESSION = requests.Session()
 _PAGESIZE = 100
 
-
 def use_proxy(http='socks5://127.0.0.1:9050', https='socks5://127.0.0.1:9050'):
     """ Routes scholarly through a proxy (e.g. tor).
         Requires pysocks
@@ -47,8 +47,7 @@ def use_proxy(http='socks5://127.0.0.1:9050', https='socks5://127.0.0.1:9050'):
     _SESSION.proxies ={
             'http': http,
             'https': https
-    }
-
+}
 
 def _handle_captcha(url):
     # TODO: PROBLEMS HERE! NEEDS ATTENTION
@@ -57,19 +56,22 @@ def _handle_captcha(url):
     captcha = _SESSION.get(captcha_url, headers=_HEADERS)
     # Upload to remote host and display to user for human verification
     img_upload = requests.post('http://postimage.org/',
-        files={'upload[]': ('scholarly_captcha.jpg', captcha.text)})
+                               files={'upload[]': ('scholarly_captcha.jpg', captcha.text)})
     print(img_upload.text)
     img_url_soup = BeautifulSoup(img_upload.text, 'html.parser')
     img_url = img_url_soup.find_all(alt='scholarly_captcha')[0].get('src')
     print('CAPTCHA image URL: {0}'.format(img_url))
     # Need to check Python version for input
-    if sys.version[0]=="3":
+    if sys.version[0] == "3":
         g_response = input('Enter CAPTCHA: ')
     else:
         g_response = raw_input('Enter CAPTCHA: ')
     # Once we get a response, follow through and load the new page.
-    url_response = _HOST+'/sorry/CaptchaRedirect?continue={0}&id={1}&captcha={2}&submit=Submit'.format(dest_url, g_id, g_response)
-    resp_captcha = _SESSION.get(url_response, headers=_HEADERS, cookies=_COOKIES)
+    url_response = _HOST + \
+        '/sorry/CaptchaRedirect?continue={0}&id={1}&captcha={2}&submit=Submit'.format(
+            dest_url, g_id, g_response)
+    resp_captcha = _SESSION.get(
+        url_response, headers=_HEADERS, cookies=_COOKIES)
     print('Forwarded to {0}'.format(resp_captcha.url))
     return resp_captcha.url
 
@@ -118,13 +120,15 @@ def _search_citation_soup(soup):
     while True:
         for row in soup.find_all('div', 'gsc_1usr'):
             yield Author(row)
-        next_button = soup.find(class_='gs_btnPR gs_in_ib gs_btn_half gs_btn_lsb gs_btn_srt gsc_pgn_pnx')
+        next_button = soup.find(
+            class_='gs_btnPR gs_in_ib gs_btn_half gs_btn_lsb gs_btn_srt gsc_pgn_pnx')
         if next_button and 'disabled' not in next_button.attrs:
             url = next_button['onclick'][17:-1]
             url = codecs.getdecoder("unicode_escape")(url)[0]
             soup = _get_soup(_HOST+url)
         else:
             break
+
 
 def _find_tag_class_name(__data, tag, text):
     elements = __data.find_all(tag)
@@ -135,45 +139,62 @@ def _find_tag_class_name(__data, tag, text):
 
 class Publication(object):
     """Returns an object for a single publication"""
+
     def __init__(self, __data, pubtype=None):
+
         self.bib = dict()
         self.source = pubtype
         if self.source == 'citations':
             self.bib['title'] = __data.find('a', class_='gsc_a_at').text
-            self.id_citations = re.findall(_CITATIONPUBRE, __data.find('a', class_='gsc_a_at')['data-href'])[0]
+            self.id_citations = re.findall(_CITATIONPUBRE, __data.find(
+                'a', class_='gsc_a_at')['data-href'])[0]
             citedby = __data.find(class_='gsc_a_ac')
             if citedby and not (citedby.text.isspace() or citedby.text == ''):
                 self.citedby = int(citedby.text)
             year = __data.find(class_='gsc_a_h')
-            if year and year.text and not year.text.isspace() and len(year.text)>0:
+            if year and year.text and not year.text.isspace() and len(year.text) > 0:
                 self.bib['year'] = int(year.text)
+
+            href = __data.find('a', "gsc_a_ac")
+            url = (((str(href).split(" "))[3]).split(">"))[0]
+
+            citeslist = url.split("cites=")
+            cites = []
+            if len(citeslist) > 1:
+                cites = (citeslist[1][:-1]).split(",")
+
+            self.id_scholarcitedby = cites
         elif self.source == 'scholar':
             databox = __data.find('div', class_='gs_ri')
             title = databox.find('h3', class_='gs_rt')
-            if title.find('span', class_='gs_ctu'): # A citation
+            if title.find('span', class_='gs_ctu'):  # A citation
                 title.span.extract()
-            elif title.find('span', class_='gs_ctc'): # A book or PDF
+            elif title.find('span', class_='gs_ctc'):  # A book or PDF
                 title.span.extract()
             self.bib['title'] = title.text.strip()
             if title.find('a'):
                 self.bib['url'] = title.find('a')['href']
             authorinfo = databox.find('div', class_='gs_a')
-            self.bib['author'] = ' and '.join([i.strip() for i in authorinfo.text.split(' - ')[0].split(',')])
+            self.bib['author'] = ' and '.join(
+                [i.strip() for i in authorinfo.text.split(' - ')[0].split(',')])
             if databox.find('div', class_='gs_rs'):
                 self.bib['abstract'] = databox.find('div', class_='gs_rs').text
                 if self.bib['abstract'][0:8].lower() == 'abstract':
                     self.bib['abstract'] = self.bib['abstract'][9:].strip()
             lowerlinks = databox.find('div', class_='gs_fl').find_all('a')
+
             for link in lowerlinks:
                 if 'Import into BibTeX' in link.text:
                     self.url_scholarbib = link['href']
                 if 'Cited by' in link.text:
                     self.citedby = int(re.findall(r'\d+', link.text)[0])
-                    self.id_scholarcitedby = re.findall(_SCHOLARPUBRE, link['href'])[0]
+                    self.id_scholarcitedby = re.findall(
+                        _SCHOLARPUBRE, link['href'])[0]
             if __data.find('div', class_='gs_ggs gs_fl'):
-                self.bib['eprint'] = __data.find('div', class_='gs_ggs gs_fl').a['href']
+                self.bib['eprint'] = __data.find(
+                    'div', class_='gs_ggs gs_fl').a['href']
         self._filled = False
-
+        
     def fill(self):
         """Populate the Publication with information from its profile"""
         if self.source == 'citations':
@@ -181,12 +202,14 @@ class Publication(object):
             soup = _get_soup(_HOST+url)
             self.bib['title'] = soup.find('div', id='gsc_vcd_title').text
             if soup.find('a', class_='gsc_vcd_title_link'):
-                self.bib['url'] = soup.find('a', class_='gsc_vcd_title_link')['href']
+                self.bib['url'] = soup.find(
+                    'a', class_='gsc_vcd_title_link')['href']
             for item in soup.find_all('div', class_='gs_scl'):
                 key = item.find(class_='gsc_vcd_field').text
                 val = item.find(class_='gsc_vcd_value')
                 if key == 'Authors':
-                    self.bib['author'] = ' and '.join([i.strip() for i in val.text.split(',')])
+                    self.bib['author'] = ' and '.join(
+                        [i.strip() for i in val.text.split(',')])
                 elif key == 'Journal':
                     self.bib['journal'] = val.text
                 elif key == 'Volume':
@@ -204,15 +227,16 @@ class Publication(object):
                         val = val.text[9:].strip()
                     self.bib['abstract'] = val
                 elif key == 'Total citations':
-                    self.id_scholarcitedby = re.findall(_SCHOLARPUBRE, val.a['href'])[0]
-
+                    self.id_scholarcitedby = re.findall(
+                        _SCHOLARPUBRE, val.a['href'])[0]
             # number of citation per year
             years = [int(y.text) for y in soup.find_all(class_='gsc_vcd_g_t')]
             cites = [int(c.text) for c in soup.find_all(class_='gsc_vcd_g_al')]
             self.cites_per_year = dict(zip(years, cites))
 
             if soup.find('div', class_='gsc_vcd_title_ggi'):
-                self.bib['eprint'] = soup.find('div', class_='gsc_vcd_title_ggi').a['href']
+                self.bib['eprint'] = soup.find(
+                    'div', class_='gsc_vcd_title_ggi').a['href']
             self._filled = True
         elif self.source == 'scholar':
             bibtex = _get_page(self.url_scholarbib)
@@ -227,7 +251,13 @@ class Publication(object):
         if not hasattr(self, 'id_scholarcitedby'):
             self.fill()
         if hasattr(self, 'id_scholarcitedby'):
-            url = _SCHOLARPUB.format(requests.utils.quote(self.id_scholarcitedby))
+
+            stringcites = ""
+            for cite in self.id_scholarcitedby:
+                stringcites += urllib.parse.quote(
+                    bytes(cite, encoding='utf8')) + ","
+
+            url = _SCHOLARPUB.format(requests.utils.quote(stringcites))
             soup = _get_soup(_HOST+url)
             return _search_scholar_soup(soup)
         else:
@@ -239,22 +269,28 @@ class Publication(object):
 
 class Author(object):
     """Returns an object for a single author"""
+
     def __init__(self, __data):
         if isinstance(__data, str):
             self.id = __data
         else:
             self.id = re.findall(_CITATIONAUTHRE, __data('a')[0]['href'])[0]
-            self.url_picture = _HOST+'/citations?view_op=medium_photo&user={}'.format(self.id)
-            self.name = __data.find('h3', class_=_find_tag_class_name(__data, 'h3', 'name')).text
-            affiliation = __data.find('div', class_=_find_tag_class_name(__data, 'div', 'aff'))
+            self.url_picture = _HOST + \
+                '/citations?view_op=medium_photo&user={}'.format(self.id)
+            self.name = __data.find(
+                'h3', class_=_find_tag_class_name(__data, 'h3', 'name')).text
+            affiliation = __data.find(
+                'div', class_=_find_tag_class_name(__data, 'div', 'aff'))
             if affiliation:
                 self.affiliation = affiliation.text
-            email = __data.find('div', class_=_find_tag_class_name(__data, 'div', 'eml'))
+            email = __data.find(
+                'div', class_=_find_tag_class_name(__data, 'div', 'eml'))
             if email:
                 self.email = re.sub(_EMAILAUTHORRE, r'@', email.text)
             self.interests = [i.text.strip() for i in
-                           __data.find_all('a', class_=_find_tag_class_name(__data, 'a', 'one_int'))]
-            citedby = __data.find('div', class_=_find_tag_class_name(__data, 'div', 'cby'))
+                              __data.find_all('a', class_=_find_tag_class_name(__data, 'a', 'one_int'))]
+            citedby = __data.find(
+                'div', class_=_find_tag_class_name(__data, 'div', 'cby'))
             if citedby and citedby.text != '':
                 self.citedby = int(citedby.text[9:])
         self._filled = False
@@ -266,8 +302,9 @@ class Author(object):
         soup = _get_soup(_HOST+url)
         self.name = soup.find('div', id='gsc_prf_in').text
         self.affiliation = soup.find('div', class_='gsc_prf_il').text
-        self.interests = [i.text.strip() for i in soup.find_all('a', class_='gsc_prf_inta')]
-        
+        self.interests = [i.text.strip()
+                          for i in soup.find_all('a', class_='gsc_prf_inta')]
+
         # h-index, i10-index and h-index, i10-index in the last 5 years
         index = soup.find_all('td', class_='gsc_rsb_std')
         if index:
@@ -288,11 +325,11 @@ class Author(object):
         # co-authors
         self.coauthors = []
         for row in soup.find_all('span', class_='gsc_rsb_a_desc'):
-            new_coauthor = Author(re.findall(_CITATIONAUTHRE, row('a')[0]['href'])[0])
+            new_coauthor = Author(re.findall(
+                _CITATIONAUTHRE, row('a')[0]['href'])[0])
             new_coauthor.name = row.find(tabindex="-1").text
             new_coauthor.affiliation = row.find(class_="gsc_rsb_a_ext").text
             self.coauthors.append(new_coauthor)
-
 
         self.publications = list()
         pubstart = 0
@@ -302,7 +339,8 @@ class Author(object):
                 self.publications.append(new_pub)
             if 'disabled' not in soup.find('button', id='gsc_bpf_more').attrs:
                 pubstart += _PAGESIZE
-                url = '{0}&cstart={1}&pagesize={2}'.format(url_citations, pubstart, _PAGESIZE)
+                url = '{0}&cstart={1}&pagesize={2}'.format(
+                    url_citations, pubstart, _PAGESIZE)
                 soup = _get_soup(_HOST+url)
             else:
                 break
@@ -347,4 +385,3 @@ def search_author_custom_url(url):
     URL should be of the form '/citation?q=...'"""
     soup = _get_soup(_HOST+url)
     return _search_citation_soup(soup)
-


### PR DESCRIPTION
Referring to this issue: https://github.com/OrganicIrradiation/scholarly/issues/47

In the Publisher init method, I extracted the list of cited publications from the URL and pushed it into id_scholarcitedby.

After that, I also had to edit the get_citedby method class.
I had to transform the list of strings in a format that is acceptable from the requests lib. To do that, I had to import "urllib" library too.