### PR TITLE
Break up Author fill into sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,58 @@ print(next(scholarly.search_author('Steven A. Cholewiak')))
  'url_scholarbib': 'https://scholar.googleusercontent.com/scholar.bib?q=info:K8ZpoI6hZNoJ:scholar.google.com/&output=citation&scisig=AAGBfm0AAAAAXGSbUf67ybEFA3NEyJzRusXRbR441api&scisf=4&ct=citation&cd=0&hl=en'}
 ```
 
+* `Author.fill(sections=['all'])` -- Populate the Author object with
+  information from their profile. The optional `sections` parameter takes a
+  list of the portions of author information to fill, as follows:
+  - `'basic'` = name, affiliation, and interests;
+  - `'citation_indices'` = h-index, i10-index, and 5-year analogues;
+  - `'citation_num'` = number of citations per year;
+  - `'co-authors'` = co-authors;
+  - `'publications'` = publications;
+  - `'all'` = all of the above (this is the default)
+
+```python
+>>> search_query = scholarly.search_author('Steven A Cholewiak')
+>>> author = next(search_query)
+>>> print(author.fill(sections=['basic', 'citation_indices', 'co-authors']))
+{'_filled': False,
+ 'affiliation': 'Vision Scientist',
+ 'citedby': 261,
+ 'citedby5y': 185,
+ 'coauthors': [<scholarly.scholarly.Author object at 0x7fdb210e0550>,
+               <scholarly.scholarly.Author object at 0x7fdb20718210>,
+               <scholarly.scholarly.Author object at 0x7fdb20718290>,
+               <scholarly.scholarly.Author object at 0x7fdb20718350>,
+               <scholarly.scholarly.Author object at 0x7fdb20718410>,
+               <scholarly.scholarly.Author object at 0x7fdb207185d0>,
+               <scholarly.scholarly.Author object at 0x7fdb207184d0>,
+               <scholarly.scholarly.Author object at 0x7fdb207186d0>,
+               <scholarly.scholarly.Author object at 0x7fdb207187d0>,
+               <scholarly.scholarly.Author object at 0x7fdb20718510>,
+               <scholarly.scholarly.Author object at 0x7fdb20718890>,
+               <scholarly.scholarly.Author object at 0x7fdb20718790>,
+               <scholarly.scholarly.Author object at 0x7fdb20718a10>,
+               <scholarly.scholarly.Author object at 0x7fdb20718ad0>,
+               <scholarly.scholarly.Author object at 0x7fdb20718c10>,
+               <scholarly.scholarly.Author object at 0x7fdb20718b90>,
+               <scholarly.scholarly.Author object at 0x7fdb20718d10>,
+               <scholarly.scholarly.Author object at 0x7fdb20718e10>,
+               <scholarly.scholarly.Author object at 0x7fdb20718bd0>,
+               <scholarly.scholarly.Author object at 0x7fdb20718f50>],
+ 'email': '@berkeley.edu',
+ 'hindex': 8,
+ 'hindex5y': 8,
+ 'i10index': 7,
+ 'i10index5y': 7,
+ 'id': '4bahYMkAAAAJ',
+ 'interests': ['Depth Cues',
+               '3D Shape',
+               'Shape from Texture & Shading',
+               'Naive Physics',
+               'Haptics'],
+ 'name': 'Steven A. Cholewiak, PhD',
+ 'url_picture': 'https://scholar.google.com/citations?view_op=medium_photo&user=4bahYMkAAAAJ'}
+```
 
 ### Example
 Here's a quick example demonstrating how to retrieve an author's profile then retrieve the titles of the papers that cite his most popular (cited) paper.

--- a/scholarly/scholarly.py
+++ b/scholarly/scholarly.py
@@ -283,7 +283,6 @@ class Author(object):
             'all' = all of the above (this is the default)
         """
         sections = [section.lower() for section in sections]
-        print(sections)
         url_citations = _CITATIONAUTH.format(self.id)
         url = '{0}&pagesize={1}'.format(url_citations, _PAGESIZE)
         soup = _get_soup(_HOST+url)

--- a/scholarly/scholarly.py
+++ b/scholarly/scholarly.py
@@ -259,55 +259,80 @@ class Author(object):
                 self.citedby = int(citedby.text[9:])
         self._filled = False
 
-    def fill(self):
-        """Populate the Author with information from their profile"""
+    def fill(self, sections=['all']):
+        """Populate the Author with information from their profile
+
+        The `sections` argument allows for finer granularity of the profile
+        information to be pulled.
+
+        Parameters
+        ----------
+        sections : list of str
+            The sections of author information that should be filled. They
+            are broken down as follows:
+            'basic' = name, affiliation, and interests;
+            'citation_indices' = h-index, i10-index, and 5-year analogues;
+            'num_citations' = number of citations per year;
+            'co-authors' = co-authors;
+            'publications' = publications;
+            'all' = all of the above (this is the default)
+        """
+        sections = [section.lower() for section in sections]
+        print(sections)
         url_citations = _CITATIONAUTH.format(self.id)
         url = '{0}&pagesize={1}'.format(url_citations, _PAGESIZE)
         soup = _get_soup(_HOST+url)
-        self.name = soup.find('div', id='gsc_prf_in').text
-        self.affiliation = soup.find('div', class_='gsc_prf_il').text
-        self.interests = [i.text.strip() for i in soup.find_all('a', class_='gsc_prf_inta')]
+        if 'basic' in sections or 'all' in sections:
+            self.name = soup.find('div', id='gsc_prf_in').text
+            self.affiliation = soup.find('div', class_='gsc_prf_il').text
+            self.interests = [i.text.strip() for i in
+                              soup.find_all('a', class_='gsc_prf_inta')]
         
         # h-index, i10-index and h-index, i10-index in the last 5 years
-        index = soup.find_all('td', class_='gsc_rsb_std')
-        if index:
-            self.citedby = int(index[0].text)
-            self.citedby5y = int(index[1].text)
-            self.hindex = int(index[2].text)
-            self.hindex5y = int(index[3].text)
-            self.i10index = int(index[4].text)
-            self.i10index5y = int(index[5].text)
-        else:
-            self.hindex = self.hindex5y = self.i10index = self.i10index5y = 0
+        if 'citation_indices' in sections or 'all' in sections:
+            index = soup.find_all('td', class_='gsc_rsb_std')
+            if index:
+                self.citedby = int(index[0].text)
+                self.citedby5y = int(index[1].text)
+                self.hindex = int(index[2].text)
+                self.hindex5y = int(index[3].text)
+                self.i10index = int(index[4].text)
+                self.i10index5y = int(index[5].text)
+            else:
+                self.hindex = self.hindex5y = self.i10index = self.i10index5y = 0
 
         # number of citations per year
-        years = [int(y.text) for y in soup.find_all('span', class_='gsc_g_t')]
-        cites = [int(c.text) for c in soup.find_all('span', class_='gsc_g_al')]
-        self.cites_per_year = dict(zip(years, cites))
+        if 'citation_num' in sections or 'all' in sections:
+            years = [int(y.text) for y in soup.find_all('span', class_='gsc_g_t')]
+            cites = [int(c.text) for c in soup.find_all('span', class_='gsc_g_al')]
+            self.cites_per_year = dict(zip(years, cites))
 
         # co-authors
-        self.coauthors = []
-        for row in soup.find_all('span', class_='gsc_rsb_a_desc'):
-            new_coauthor = Author(re.findall(_CITATIONAUTHRE, row('a')[0]['href'])[0])
-            new_coauthor.name = row.find(tabindex="-1").text
-            new_coauthor.affiliation = row.find(class_="gsc_rsb_a_ext").text
-            self.coauthors.append(new_coauthor)
+        if 'co-authors' in sections or 'all' in sections:
+            self.coauthors = []
+            for row in soup.find_all('span', class_='gsc_rsb_a_desc'):
+                new_coauthor = Author(re.findall(_CITATIONAUTHRE, row('a')[0]['href'])[0])
+                new_coauthor.name = row.find(tabindex="-1").text
+                new_coauthor.affiliation = row.find(class_="gsc_rsb_a_ext").text
+                self.coauthors.append(new_coauthor)
 
 
-        self.publications = list()
-        pubstart = 0
-        while True:
-            for row in soup.find_all('tr', class_='gsc_a_tr'):
-                new_pub = Publication(row, 'citations')
-                self.publications.append(new_pub)
-            if 'disabled' not in soup.find('button', id='gsc_bpf_more').attrs:
-                pubstart += _PAGESIZE
-                url = '{0}&cstart={1}&pagesize={2}'.format(url_citations, pubstart, _PAGESIZE)
-                soup = _get_soup(_HOST+url)
-            else:
-                break
+        if 'publications' in sections or 'all' in sections:
+            self.publications = list()
+            pubstart = 0
+            while True:
+                for row in soup.find_all('tr', class_='gsc_a_tr'):
+                    new_pub = Publication(row, 'citations')
+                    self.publications.append(new_pub)
+                if 'disabled' not in soup.find('button', id='gsc_bpf_more').attrs:
+                    pubstart += _PAGESIZE
+                    url = '{0}&cstart={1}&pagesize={2}'.format(url_citations, pubstart, _PAGESIZE)
+                    soup = _get_soup(_HOST+url)
+                else:
+                    break
 
-        self._filled = True
+        if 'all' in sections:
+            self._filled = True
         return self
 
     def __str__(self):

--- a/scholarly/test.py
+++ b/scholarly/test.py
@@ -35,15 +35,15 @@ class TestScholarly(unittest.TestCase):
         self.assertIn(u'Steven A. Cholewiak, PhD', authors)
 
     def test_multiple_authors(self):
-        ''' As of 2020-04-30 there are 88 'Zucker's '''
+        ''' As of 2020-05-06 there are 89 'Zucker's '''
         authors = [a.name for a in scholarly.search_author('Zucker')]
-        self.assertEqual(len(authors), 88)
+        self.assertEqual(len(authors), 89)
         self.assertIn(u'Steven W Zucker', authors)
 
     def test_multiple_publications(self):
-        ''' As of March 14, 2019 there are 28 pubs that fit the search term'''
+        ''' As of 2020-05-06 there are 29 pubs that fit the search term'''
         pubs = [p.bib['title'] for p in scholarly.search_pubs_query('"naive physics" stability "3d shape"')]
-        self.assertEqual(len(pubs), 28)
+        self.assertEqual(len(pubs), 29)
         self.assertIn(u'Visual perception of the physical stability of asymmetric three-dimensional objects', pubs)
 
     def test_publication_contents(self):
@@ -60,7 +60,7 @@ class TestScholarly(unittest.TestCase):
 
     def test_single_author(self):
         author = next(scholarly.search_author('Steven A. Cholewiak')).fill()
-        self.assertEqual(author.name, u'Steven A. Cholewiak')
+        self.assertEqual(author.name, u'Steven A. Cholewiak, PhD')
         self.assertEqual(author.id, u'4bahYMkAAAAJ')
 
 if __name__ == '__main__':

--- a/scholarly/test.py
+++ b/scholarly/test.py
@@ -1,16 +1,24 @@
 import unittest
 import scholarly
 
+# TODO a number of these tests are out of date with the current information on
+# Google Scholar. This is the obvious downside of designing static tests that
+# rely on dynamic external data.
 class TestScholarly(unittest.TestCase):
 
     def test_empty_author(self):
+        '''Test that sholarly.search_author('') returns no authors'''
         authors = [a for a in scholarly.search_author('')]
         self.assertIs(len(authors), 0)
 
     def test_empty_keyword(self):
-        ''' Returns 4 individuals with the name 'label' '''
+        ''' As of 2020-04-30, there are  6 individuals that match the name
+        'label' '''
+        # TODO this seems like undesirable functionality for
+        # scholarly.search_keyword() with empty string. Surely, no authors
+        # should be returned. Consider modifying the method itself.
         authors = [a for a in scholarly.search_keyword('')]
-        self.assertEqual(len(authors), 4)
+        self.assertEqual(len(authors), 6)
 
     def test_empty_publication(self):
         pubs = [p for p in scholarly.search_pubs_query('')]
@@ -24,12 +32,12 @@ class TestScholarly(unittest.TestCase):
     def test_keyword(self):
         authors = [a.name for a in scholarly.search_keyword('3d_shape')]
         self.assertIsNot(len(authors), 0)
-        self.assertIn(u'Steven A. Cholewiak', authors)
+        self.assertIn(u'Steven A. Cholewiak, PhD', authors)
 
     def test_multiple_authors(self):
-        ''' As of March 14, 2019 there are 34 'Zucker's '''
+        ''' As of 2020-04-30 there are 88 'Zucker's '''
         authors = [a.name for a in scholarly.search_author('Zucker')]
-        self.assertEqual(len(authors), 58)
+        self.assertEqual(len(authors), 88)
         self.assertIn(u'Steven W Zucker', authors)
 
     def test_multiple_publications(self):


### PR DESCRIPTION
As mentioned in #18 it is desirable to not get the publications for an author when filling it because of the time this takes. I have taken the idea from that pull request further and made sections for Author information that can be selectively filled.

As a subtask, I updated the tests to reflect the current data from Google Scholar. This was also done at a previous point in time on #60, but those numbers will now also be out of date. It is likely that the tests should be redesigned to depend on less dynamic data from Google Scholar, apart from the "greater than or equal" condition as suggested in #60. 